### PR TITLE
Adding support for descriptor_value for request_headers method

### DIFF
--- a/api/v1alpha1/globalratelimit_types.go
+++ b/api/v1alpha1/globalratelimit_types.go
@@ -56,6 +56,8 @@ type GlobalRateLimit_Action_RequestHeaders struct {
 	// value is used to populate the value of the descriptor entry for the
 	// descriptor_key.
 	HeaderName string `json:"header_name,omitempty" yaml:"header_name,omitempty"`
+	// The value to use in the descriptor entry.
+	DescriptorValue string `json:"descriptor_value,omitempty" yaml:"descriptor_value,omitempty"`
 	// The key to use in the descriptor entry.
 	DescriptorKey string `json:"descriptor_key,omitempty" yaml:"descriptor_key,omitempty"`
 	// If set to true, Envoy skips the descriptor while calling rate limiting service

--- a/api/v1alpha1/globalratelimit_types.go
+++ b/api/v1alpha1/globalratelimit_types.go
@@ -57,7 +57,7 @@ type GlobalRateLimit_Action_RequestHeaders struct {
 	// descriptor_key.
 	HeaderName string `json:"header_name,omitempty" yaml:"header_name,omitempty"`
 	// The value to use in the descriptor entry.
-	DescriptorValue string `json:"descriptor_value,omitempty" yaml:"descriptor_value,omitempty"`
+	DescriptorValue *string `json:"descriptor_value,omitempty" yaml:"descriptor_value,omitempty"`
 	// The key to use in the descriptor entry.
 	DescriptorKey string `json:"descriptor_key,omitempty" yaml:"descriptor_key,omitempty"`
 	// If set to true, Envoy skips the descriptor while calling rate limiting service

--- a/charts/istio-ratelimit-operator/Chart.yaml
+++ b/charts/istio-ratelimit-operator/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: istio-ratelimit-operator
 description: Istio ratelimit operator provide an easy way to configure Global or Local Ratelimit in Istio mesh. Istio ratelimit operator also support EnvoyFilter versioning!
-version: 2.5.1
-appVersion: 2.5.1
+version: 2.5.2
+appVersion: 2.5.2
 type: application
 home: https://github.com/zufardhiyaulhaq/istio-ratelimit-operator
 

--- a/charts/istio-ratelimit-operator/crds/crds.yaml
+++ b/charts/istio-ratelimit-operator/crds/crds.yaml
@@ -245,6 +245,9 @@ spec:
                       type: object
                     request_headers:
                       properties:
+                        descriptor_value:
+                          description: The value to use in the descriptor entry.
+                          type: string
                         descriptor_key:
                           description: The key to use in the descriptor entry.
                           type: string

--- a/pkg/global/ratelimit/v3_gateway_builder_test.go
+++ b/pkg/global/ratelimit/v3_gateway_builder_test.go
@@ -58,6 +58,7 @@ var V3GatewayBuilderTestGrid = []V3GatewayBuilderTestCase{
 						RequestHeaders: &v1alpha1.GlobalRateLimit_Action_RequestHeaders{
 							HeaderName:    ":method",
 							DescriptorKey: "hello-zufardhiyaulhaq-dev-header-method",
+							DescriptorValue: "GET",
 						},
 					},
 				},

--- a/pkg/global/ratelimit/v3_sidecar_builder_test.go
+++ b/pkg/global/ratelimit/v3_sidecar_builder_test.go
@@ -58,6 +58,7 @@ var V3SidecarBuilderTestGrid = []V3SidecarBuilderTestCase{
 						RequestHeaders: &v1alpha1.GlobalRateLimit_Action_RequestHeaders{
 							HeaderName:    ":method",
 							DescriptorKey: "hello-zufardhiyaulhaq-dev-header-method",
+							DescriptorValue: "GET",
 						},
 					},
 				},

--- a/pkg/service/configmap_config_builder.go
+++ b/pkg/service/configmap_config_builder.go
@@ -134,6 +134,7 @@ func NewRateLimitDescriptorFromMatcher(matchers []*v1alpha1.GlobalRateLimit_Acti
 
 	if matcher.RequestHeaders != nil {
 		descriptor[0].Key = matcher.RequestHeaders.DescriptorKey
+		descriptor[0].Value = matcher.RequestHeaders.DescriptorValue
 
 		if len(matchers) == 1 {
 			descriptor[0].RateLimit.RequestsPerUnit = limit.RequestsPerUnit


### PR DESCRIPTION
Issue : https://github.com/zufardhiyaulhaq/istio-ratelimit-operator/issues/16


### Summary
We need to add suppport for descriptor_value for request_headers method

### Type of Change
Adding funcunallity 

### How has this been tested?
Deployed rate limit to my cluster with the following configuation.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/275991/175906041-04faaec4-f052-4c04-909c-a00ccf818b91.png">

<img width="1087" alt="image" src="https://user-images.githubusercontent.com/275991/175906210-420ae458-5a31-4bcb-b66f-0d6949b7a8c6.png">

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have written new tests for my changes.
- [x ] My changes successfully ran and pass tests locally.
