### PR TITLE
(wip) shadow mode feature

### DIFF
--- a/api/v1alpha1/ratelimitservice_types.go
+++ b/api/v1alpha1/ratelimitservice_types.go
@@ -32,6 +32,7 @@ type RateLimitServiceSpec_Kubernetes struct {
 	ReplicaCount *int32                                       `json:"replica_count,omitempty"`
 	Resources    *corev1.ResourceRequirements                 `json:"resources,omitempty"`
 	AutoScaling  *RateLimitServiceSpec_Kubernetes_AutoScaling `json:"auto_scaling,omitempty"`
+	ShadowMode   bool                                         `json:"shadow_mode"`
 }
 
 type RateLimitServiceSpec_Kubernetes_AutoScaling struct {

--- a/charts/istio-ratelimit-operator/crds/crds.yaml
+++ b/charts/istio-ratelimit-operator/crds/crds.yaml
@@ -159,6 +159,8 @@ spec:
                   unit:
                     type: string
                 type: object
+              shadow_mode:
+                type: boolean
               matcher:
                 items:
                   properties:

--- a/charts/istio-ratelimit-operator/crds/crds.yaml
+++ b/charts/istio-ratelimit-operator/crds/crds.yaml
@@ -362,6 +362,8 @@ spec:
                         format: int32
                         type: integer
                     type: object
+                  shadow_mode:
+                    type: boolean
                   replica_count:
                     format: int32
                     type: integer

--- a/pkg/service/deployment_builder.go
+++ b/pkg/service/deployment_builder.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strconv"
+
 	"github.com/zufardhiyaulhaq/istio-ratelimit-operator/api/v1alpha1"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -133,6 +135,10 @@ func (n *DeploymentBuilder) BuildEnv() []corev1.EnvVar {
 		{
 			Name:  "RUNTIME_IGNOREDOTFILES",
 			Value: "true",
+		},
+		{
+			Name:  "SHADOW_MODE",
+			Value: strconv.FormatBool(n.RateLimitService.Spec.Kubernetes.ShadowMode),
 		},
 	}
 

--- a/pkg/types/ratelimit.go
+++ b/pkg/types/ratelimit.go
@@ -15,6 +15,7 @@ type RateLimit_Service_Descriptor struct {
 	Value       string                         `json:"value,omitempty" yaml:"value,omitempty"`
 	RateLimit   v1alpha1.GlobalRateLimit_Limit `json:"rate_limit,omitempty" yaml:"rate_limit,omitempty"`
 	Descriptors []RateLimit_Service_Descriptor `json:"descriptors,omitempty" yaml:"descriptors,omitempty"`
+	ShadowMode  bool                           `json:"shadow_mode" yaml:"shadow_mode"`
 }
 
 func (n *RateLimit_Service_Config) String() (string, error) {

--- a/pkg/types/ratelimit_test.go
+++ b/pkg/types/ratelimit_test.go
@@ -23,8 +23,9 @@ func TestRateLimit_Service_Config_String(t *testing.T) {
 				Domain: "foo",
 				Descriptors: []RateLimit_Service_Descriptor{
 					{
-						Key:   "bar",
-						Value: "baz",
+						Key:        "bar",
+						Value:      "baz",
+						ShadowMode: false,
 						RateLimit: v1alpha1.GlobalRateLimit_Limit{
 							Unit:            "hour",
 							RequestsPerUnit: 1,
@@ -39,6 +40,7 @@ descriptors:
   rate_limit:
     unit: hour
     requests_per_unit: 1
+  shadow_mode: false
 `,
 			wantErr: false,
 		},


### PR DESCRIPTION
### Summary
This PR implements the usage of [shadow_mode](https://github.com/envoyproxy/ratelimit#shadowmode) of envoyproxy ratelimit service inside this operator, this is implemented in two ways, the first, enabling the global shadow_mode inside the RateLimitService manifest, so the deployment will include the `SHADOW_MODE` environment variable for this service as described in the official documentation and the second one enabling the shadow_mode per rule.
### Type of Change
This PR fixes/implements the following **bugs/features**:

- shadow_mode usage inside istio-ratelimit-operator

<!-- What existing problem does the pull request solve? -->

### How has this been tested?
Proof:
For the global shadow_mode:
RateLimitService manifest
```
---
apiVersion: ratelimit.zufardhiyaulhaq.com/v1alpha1
kind: RateLimitService
metadata:
  name: istio-test-ratelimit-service
  namespace: istio-system
spec:
  kubernetes:
    shadow_mode: true
    replica_count: 2
    auto_scaling:
      max_replicas: 3
      min_replicas: 2
    resources:
      limits:
        cpu: "256m"
        memory: "256Mi"
      requests:
        cpu: "128m"
        memory: "128Mi"
  backend:
    redis:
      type: "single"
      url: "redis.istio-system.svc.cluster.local:6379"
```
After the deployment:
![ ](https://user-images.githubusercontent.com/31141/188672104-c12aacce-9bf9-4561-975d-bc9a82a8f6a4.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output or/ screenshots. -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.

Closes #18
