### PR TITLE
use FQDN when connecting gateway or sidecar to ratelimitservice

### DIFF
--- a/controllers/globalratelimitconfig_controller.go
+++ b/controllers/globalratelimitconfig_controller.go
@@ -78,7 +78,7 @@ func (r *GlobalRateLimitConfigReconciler) Reconcile(ctx context.Context, req ctr
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
-		globalRateLimitConfig.Spec.Ratelimit.Spec.Service.Address = rateLimitServiceObject.Name + "." + rateLimitServiceObject.Namespace + ".svc"
+		globalRateLimitConfig.Spec.Ratelimit.Spec.Service.Address = rateLimitServiceObject.Name + "." + rateLimitServiceObject.Namespace + ".svc.cluster.local"
 		globalRateLimitConfig.Spec.Ratelimit.Spec.Service.Port = 8081
 	}
 


### PR DESCRIPTION
Signed-off-by: zufardhiyaulhaq <zufardhiyaulhaq@gmail.com>

Envoyfilter created for GlobalRateLimitConfig to connect gateway or sidecar to RateLimitService is not using FQDN and cause cluster with aggressive ndots fails.

### Type of Change
This PR fixes/implements the following **bugs/features**:

- Using FQDN to connect to ratelimitservice

<!-- What existing problem does the pull request solve? -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] I have written new tests for my changes.
  - [ ] My changes successfully ran and pass tests locally.
