### PR TITLE
fix: remote_address not working

### DIFF
--- a/pkg/global/ratelimit/v3_gateway_builder_test.go
+++ b/pkg/global/ratelimit/v3_gateway_builder_test.go
@@ -3,23 +3,28 @@ package ratelimit_test
 import (
 	"testing"
 
+	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 	"github.com/zufardhiyaulhaq/istio-ratelimit-operator/api/v1alpha1"
 	"github.com/zufardhiyaulhaq/istio-ratelimit-operator/pkg/global/ratelimit"
 
+	proto_types "github.com/gogo/protobuf/types"
+	networking "istio.io/api/networking/v1alpha3"
+	clientnetworking "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type V3GatewayBuilderTestCase struct {
-	name          string
-	config        v1alpha1.GlobalRateLimitConfig
-	ratelimit     v1alpha1.GlobalRateLimit
-	expectedError bool
+	name                string
+	config              v1alpha1.GlobalRateLimitConfig
+	ratelimit           v1alpha1.GlobalRateLimit
+	expectedError       bool
+	expectedEnvoyFilter clientnetworking.EnvoyFilter
 }
 
 var V3GatewayBuilderTestGrid = []V3GatewayBuilderTestCase{
 	{
-		name: "given correct ratelimit",
+		name: "given correct ratelimit with request header",
 		config: v1alpha1.GlobalRateLimitConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "public-gateway-config",
@@ -64,6 +69,453 @@ var V3GatewayBuilderTestGrid = []V3GatewayBuilderTestCase{
 			},
 		},
 		expectedError: false,
+		expectedEnvoyFilter: clientnetworking.EnvoyFilter{
+			Spec: networking.EnvoyFilter{
+				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+					{
+						Patch: &networking.EnvoyFilter_Patch{
+							Value: &proto_types.Struct{
+								Fields: map[string]*proto_types.Value{
+									"route": {
+										Kind: &proto_types.Value_StructValue{
+											StructValue: &proto_types.Struct{
+												Fields: map[string]*proto_types.Value{
+													"rate_limits": {
+														Kind: &proto_types.Value_ListValue{
+															ListValue: &proto_types.ListValue{
+																Values: []*proto_types.Value{
+																	{
+																		Kind: &proto_types.Value_StructValue{
+																			StructValue: &proto_types.Struct{
+																				Fields: map[string]*proto_types.Value{
+																					"actions": {
+																						Kind: &proto_types.Value_ListValue{
+																							ListValue: &proto_types.ListValue{
+																								Values: []*proto_types.Value{
+																									{
+																										Kind: &proto_types.Value_StructValue{
+																											StructValue: &proto_types.Struct{
+																												Fields: map[string]*proto_types.Value{
+																													"request_headers": {
+																														Kind: &proto_types.Value_StructValue{
+																															StructValue: &proto_types.Struct{
+																																Fields: map[string]*proto_types.Value{
+																																	"descriptor_key": {
+																																		Kind: &proto_types.Value_StringValue{
+																																			StringValue: "hello-zufardhiyaulhaq-dev-header-method",
+																																		},
+																																	},
+																																	"header_name": {
+																																		Kind: &proto_types.Value_StringValue{
+																																			StringValue: ":method",
+																																		},
+																																	},
+																																},
+																															},
+																														},
+																													},
+																												},
+																											},
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "given correct ratelimit with remote address",
+		config: v1alpha1.GlobalRateLimitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-gateway-config",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitConfigSpec{
+				Type: "gateway",
+				Selector: v1alpha1.GlobalRateLimitConfigSelector{
+					IstioVersion: []string{"1.9"},
+				},
+				Ratelimit: v1alpha1.GlobalRateLimitConfigRatelimit{
+					Spec: v1alpha1.GlobalRateLimitConfigRatelimitSpec{
+						Domain:          "global",
+						FailureModeDeny: false,
+						Timeout:         "10s",
+						Service: v1alpha1.GlobalRateLimitConfigRatelimitSpecService{
+							Address: "grpc-testing.default",
+							Port:    3000,
+						},
+					},
+				},
+			},
+		},
+		ratelimit: v1alpha1.GlobalRateLimit{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello-zufardhiyaulhaq-dev",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitSpec{
+				Config: "public-gateway-config",
+				Selector: v1alpha1.GlobalRateLimitSelector{
+					VHost: "hello.zufardhiyaulhaq.dev:443",
+				},
+				Matcher: []*v1alpha1.GlobalRateLimit_Action{
+					{
+						RemoteAddress: &v1alpha1.GlobalRateLimit_Action_RemoteAddress{},
+					},
+				},
+			},
+		},
+		expectedError: false,
+		expectedEnvoyFilter: clientnetworking.EnvoyFilter{
+			Spec: networking.EnvoyFilter{
+				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+					{
+						Patch: &networking.EnvoyFilter_Patch{
+							Value: &proto_types.Struct{
+								Fields: map[string]*proto_types.Value{
+									"route": {
+										Kind: &proto_types.Value_StructValue{
+											StructValue: &proto_types.Struct{
+												Fields: map[string]*proto_types.Value{
+													"rate_limits": {
+														Kind: &proto_types.Value_ListValue{
+															ListValue: &proto_types.ListValue{
+																Values: []*proto_types.Value{
+																	{
+																		Kind: &proto_types.Value_StructValue{
+																			StructValue: &proto_types.Struct{
+																				Fields: map[string]*proto_types.Value{
+																					"actions": {
+																						Kind: &proto_types.Value_ListValue{
+																							ListValue: &proto_types.ListValue{
+																								Values: []*proto_types.Value{
+																									{
+																										Kind: &proto_types.Value_StructValue{
+																											StructValue: &proto_types.Struct{
+																												Fields: map[string]*proto_types.Value{
+																													"remote_address": {
+																														Kind: &proto_types.Value_StructValue{
+																															StructValue: &proto_types.Struct{
+																																Fields: map[string]*proto_types.Value{},
+																															},
+																														},
+																													},
+																												},
+																											},
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "given correct ratelimit with generic key",
+		config: v1alpha1.GlobalRateLimitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-gateway-config",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitConfigSpec{
+				Type: "gateway",
+				Selector: v1alpha1.GlobalRateLimitConfigSelector{
+					IstioVersion: []string{"1.9"},
+				},
+				Ratelimit: v1alpha1.GlobalRateLimitConfigRatelimit{
+					Spec: v1alpha1.GlobalRateLimitConfigRatelimitSpec{
+						Domain:          "global",
+						FailureModeDeny: false,
+						Timeout:         "10s",
+						Service: v1alpha1.GlobalRateLimitConfigRatelimitSpecService{
+							Address: "grpc-testing.default",
+							Port:    3000,
+						},
+					},
+				},
+			},
+		},
+		ratelimit: v1alpha1.GlobalRateLimit{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello-zufardhiyaulhaq-dev",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitSpec{
+				Config: "public-gateway-config",
+				Selector: v1alpha1.GlobalRateLimitSelector{
+					VHost: "hello.zufardhiyaulhaq.dev:443",
+				},
+				Matcher: []*v1alpha1.GlobalRateLimit_Action{
+					{
+						GenericKey: &v1alpha1.GlobalRateLimit_Action_GenericKey{
+							DescriptorKey:   swag.String("foo"),
+							DescriptorValue: "bar",
+						},
+					},
+				},
+			},
+		},
+		expectedError: false,
+		expectedEnvoyFilter: clientnetworking.EnvoyFilter{
+			Spec: networking.EnvoyFilter{
+				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+					{
+						Patch: &networking.EnvoyFilter_Patch{
+							Value: &proto_types.Struct{
+								Fields: map[string]*proto_types.Value{
+									"route": {
+										Kind: &proto_types.Value_StructValue{
+											StructValue: &proto_types.Struct{
+												Fields: map[string]*proto_types.Value{
+													"rate_limits": {
+														Kind: &proto_types.Value_ListValue{
+															ListValue: &proto_types.ListValue{
+																Values: []*proto_types.Value{
+																	{
+																		Kind: &proto_types.Value_StructValue{
+																			StructValue: &proto_types.Struct{
+																				Fields: map[string]*proto_types.Value{
+																					"actions": {
+																						Kind: &proto_types.Value_ListValue{
+																							ListValue: &proto_types.ListValue{
+																								Values: []*proto_types.Value{
+																									{
+																										Kind: &proto_types.Value_StructValue{
+																											StructValue: &proto_types.Struct{
+																												Fields: map[string]*proto_types.Value{
+																													"generic_key": {
+																														Kind: &proto_types.Value_StructValue{
+																															StructValue: &proto_types.Struct{
+																																Fields: map[string]*proto_types.Value{
+																																	"descriptor_key": {
+																																		Kind: &proto_types.Value_StringValue{
+																																			StringValue: "foo",
+																																		},
+																																	},
+																																	"descriptor_value": {
+																																		Kind: &proto_types.Value_StringValue{
+																																			StringValue: "bar",
+																																		},
+																																	},
+																																},
+																															},
+																														},
+																													},
+																												},
+																											},
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	{
+		name: "given correct ratelimit with header value match",
+		config: v1alpha1.GlobalRateLimitConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "public-gateway-config",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitConfigSpec{
+				Type: "gateway",
+				Selector: v1alpha1.GlobalRateLimitConfigSelector{
+					IstioVersion: []string{"1.9"},
+				},
+				Ratelimit: v1alpha1.GlobalRateLimitConfigRatelimit{
+					Spec: v1alpha1.GlobalRateLimitConfigRatelimitSpec{
+						Domain:          "global",
+						FailureModeDeny: false,
+						Timeout:         "10s",
+						Service: v1alpha1.GlobalRateLimitConfigRatelimitSpecService{
+							Address: "grpc-testing.default",
+							Port:    3000,
+						},
+					},
+				},
+			},
+		},
+		ratelimit: v1alpha1.GlobalRateLimit{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hello-zufardhiyaulhaq-dev",
+				Namespace: "istio-system",
+			},
+			Spec: v1alpha1.GlobalRateLimitSpec{
+				Config: "public-gateway-config",
+				Selector: v1alpha1.GlobalRateLimitSelector{
+					VHost: "hello.zufardhiyaulhaq.dev:443",
+				},
+				Matcher: []*v1alpha1.GlobalRateLimit_Action{
+					{
+						HeaderValueMatch: &v1alpha1.GlobalRateLimit_Action_HeaderValueMatch{
+							DescriptorValue: "foo",
+							ExpectMatch:     swag.Bool(true),
+							Headers: []*v1alpha1.GlobalRateLimit_Action_HeaderValueMatch_HeaderMatcher{
+								{
+									Name:       "x-header-foo",
+									ExactMatch: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		expectedError: false,
+		expectedEnvoyFilter: clientnetworking.EnvoyFilter{
+			Spec: networking.EnvoyFilter{
+				ConfigPatches: []*networking.EnvoyFilter_EnvoyConfigObjectPatch{
+					{
+						Patch: &networking.EnvoyFilter_Patch{
+							Value: &proto_types.Struct{
+								Fields: map[string]*proto_types.Value{
+									"route": {
+										Kind: &proto_types.Value_StructValue{
+											StructValue: &proto_types.Struct{
+												Fields: map[string]*proto_types.Value{
+													"rate_limits": {
+														Kind: &proto_types.Value_ListValue{
+															ListValue: &proto_types.ListValue{
+																Values: []*proto_types.Value{
+																	{
+																		Kind: &proto_types.Value_StructValue{
+																			StructValue: &proto_types.Struct{
+																				Fields: map[string]*proto_types.Value{
+																					"actions": {
+																						Kind: &proto_types.Value_ListValue{
+																							ListValue: &proto_types.ListValue{
+																								Values: []*proto_types.Value{
+																									{
+																										Kind: &proto_types.Value_StructValue{
+																											StructValue: &proto_types.Struct{
+																												Fields: map[string]*proto_types.Value{
+																													"header_value_match": {
+																														Kind: &proto_types.Value_StructValue{
+																															StructValue: &proto_types.Struct{
+																																Fields: map[string]*proto_types.Value{
+																																	"descriptor_value": {
+																																		Kind: &proto_types.Value_StringValue{
+																																			StringValue: "foo",
+																																		},
+																																	},
+																																	"expect_match": {
+																																		Kind: &proto_types.Value_BoolValue{
+																																			BoolValue: true,
+																																		},
+																																	},
+																																	"headers": {
+																																		Kind: &proto_types.Value_ListValue{
+																																			ListValue: &proto_types.ListValue{
+																																				Values: []*proto_types.Value{
+																																					{
+																																						Kind: &proto_types.Value_StructValue{
+																																							StructValue: &proto_types.Struct{
+																																								Fields: map[string]*proto_types.Value{
+																																									"exact_match": {
+																																										Kind: &proto_types.Value_StringValue{
+																																											StringValue: "foo",
+																																										},
+																																									},
+																																									"name": {
+																																										Kind: &proto_types.Value_StringValue{
+																																											StringValue: "x-header-foo",
+																																										},
+																																									},
+																																								},
+																																							},
+																																						},
+																																					},
+																																				},
+																																			},
+																																		},
+																																	},
+																																},
+																															},
+																														},
+																													},
+																												},
+																											},
+																										},
+																									},
+																								},
+																							},
+																						},
+																					},
+																				},
+																			},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 }
 
@@ -79,6 +531,9 @@ func TestNewV3GatewayBuilder(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.ratelimit.Name+"-"+"1.9", envoyfilter.Name)
 				assert.Equal(t, test.ratelimit.Namespace, envoyfilter.Namespace)
+
+				// match value generated
+				assert.Equal(t, test.expectedEnvoyFilter.Spec.ConfigPatches[0].Patch.Value, envoyfilter.Spec.ConfigPatches[0].Patch.Value)
 			}
 		})
 	}

--- a/pkg/service/configmap_config_builder_test.go
+++ b/pkg/service/configmap_config_builder_test.go
@@ -95,6 +95,32 @@ func TestNewRateLimitDescriptorFromMatcher(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "simple remote address",
+			args: args{
+				matchers: []*v1alpha1.GlobalRateLimit_Action{
+					{
+						RemoteAddress: &v1alpha1.GlobalRateLimit_Action_RemoteAddress{},
+					},
+				},
+				limit: &v1alpha1.GlobalRateLimit_Limit{
+					Unit:            "hour",
+					RequestsPerUnit: 1,
+				},
+				shadowMode: false,
+			},
+			want: []types.RateLimit_Service_Descriptor{
+				{
+					Key: "remote_address",
+					RateLimit: v1alpha1.GlobalRateLimit_Limit{
+						Unit:            "hour",
+						RequestsPerUnit: 1,
+					},
+					ShadowMode: false,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "simple Generic key",
 			args: args{
 				matchers: []*v1alpha1.GlobalRateLimit_Action{


### PR DESCRIPTION


### Summary
currently we can use remote_address on global ratelimit matcher, but it's not affecting the traffic. this add remote_address on ratelimit service configuration.

### Type of Change
This PR fixes/implements the following **bugs/features**:
- fix remote_address not working

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have written new tests for my changes.
  - [x] My changes successfully ran and pass tests locally.
