### PR TITLE
chore(chart): bump chart version to 2.16.0

### DIFF
--- a/charts/istio-ratelimit-operator/Chart.yaml
+++ b/charts/istio-ratelimit-operator/Chart.yaml
@@ -2,8 +2,8 @@
 apiVersion: v2
 name: istio-ratelimit-operator
 description: Istio ratelimit operator provide an easy way to configure Global or Local Ratelimit in Istio mesh. Istio ratelimit operator also support EnvoyFilter versioning!
-version: 2.15.0
-appVersion: 2.15.0
+version: 2.16.0
+appVersion: 2.16.0
 type: application
 home: https://github.com/zufardhiyaulhaq/istio-ratelimit-operator
 


### PR DESCRIPTION
## Summary

Update Helm chart version and appVersion to 2.16.0 to align with the released operator version.

## Changes

- Bump `version` from 2.15.0 to 2.16.0
- Bump `appVersion` from 2.15.0 to 2.16.0

## Context

The operator v2.16.0 was released but the Helm chart version was not updated accordingly. This PR fixes the version mismatch.